### PR TITLE
Skiller ut helsepersonellWS i en egen klient

### DIFF
--- a/src/main/kotlin/no/nav/syfo/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/Bootstrap.kt
@@ -13,6 +13,7 @@ import io.ktor.features.StatusPages
 import io.ktor.http.HttpStatusCode
 import io.ktor.jackson.jackson
 import io.ktor.response.respond
+import io.ktor.routing.get
 import io.ktor.routing.routing
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
@@ -81,6 +82,11 @@ fun Application.initRouting(applicationState: ApplicationState, personV3: Person
     routing {
         registerNaisApi(readynessCheck = { applicationState.ready }, livenessCheck = { applicationState.running })
         registerRuleApi(personV3, helsepersonellClient, legeSuspensjonClient, syketilfelleClient)
+
+        get("internal/register/helsepersonell") {
+            val legeFnr: String = call.request.queryParameters["legeFnr"] ?: ""
+            helsepersonellClient.hentLege(legeFnr)
+        }
     }
     install(ContentNegotiation) {
         jackson {

--- a/src/main/kotlin/no/nav/syfo/api/HelsepersonellClient.kt
+++ b/src/main/kotlin/no/nav/syfo/api/HelsepersonellClient.kt
@@ -1,0 +1,91 @@
+package no.nav.syfo.api
+
+import com.ctc.wstx.exc.WstxException
+import no.nav.syfo.helpers.retry
+import no.nav.syfo.ws.createPort
+import no.nhn.schemas.reg.hprv2.IHPR2Service
+import no.nhn.schemas.reg.hprv2.Person
+import org.apache.cxf.binding.soap.SoapMessage
+import org.apache.cxf.binding.soap.interceptor.AbstractSoapInterceptor
+import org.apache.cxf.message.Message
+import org.apache.cxf.phase.Phase
+import org.apache.cxf.ws.addressing.WSAddressingFeature
+import java.io.IOException
+import java.util.GregorianCalendar
+
+class HelsepersonellClient(
+    helsepersonellv1EndpointURL: String,
+    serviceuserUsername: String,
+    serviceuserPassword: String,
+    securityTokenServiceURL: String
+) {
+    val helsePersonellV1 = createPort<IHPR2Service>(helsepersonellv1EndpointURL) {
+        proxy {
+            // TODO: Contact someone about this hacky workaround
+            // talk to HDIR about HPR about they claim to send a ISO-8859-1 but its really UTF-8 payload
+            val interceptor = object : AbstractSoapInterceptor(Phase.RECEIVE) {
+                override fun handleMessage(message: SoapMessage?) {
+                    if (message != null)
+                        message[Message.ENCODING] = "utf-8"
+                }
+            }
+
+            inInterceptors.add(interceptor)
+            inFaultInterceptors.add(interceptor)
+            features.add(WSAddressingFeature())
+        }
+
+        port { withSTS(serviceuserUsername, serviceuserPassword, securityTokenServiceURL) }
+    }
+
+    suspend fun hentLege(doctorIdent: String): Lege =
+        retry(
+            callName = "hpr_hent_person_med_personnummer",
+            retryIntervals = arrayOf(500L, 1000L, 3000L, 5000L, 10000L),
+            legalExceptions = *arrayOf(IOException::class, WstxException::class)
+        ) {
+            val wsHelsePerson: Person = helsePersonellV1.hentPersonMedPersonnummer(
+                doctorIdent,
+                datatypeFactory.newXMLGregorianCalendar(GregorianCalendar())
+            )
+            ws2Lege(wsHelsePerson)
+                .also {
+                    log.info("fant lege i register med {} godkjenninger", it.godkjenninger.size)
+                    it.godkjenninger.forEach {godkjenning ->
+                        log.info("autorisasjon a/v/o: {}/{}/[}", godkjenning.autorisasjon?.aktiv, godkjenning.autorisasjon?.verdi, godkjenning.autorisasjon?.oid  )
+                        log.info("helsepersonell a/v/o: {}/{}/[}", godkjenning.helsepersonellkategori?.aktiv, godkjenning.helsepersonellkategori?.verdi, godkjenning.helsepersonellkategori?.oid  )
+                    }
+                }
+        }
+}
+
+fun ws2Lege(person: Person): Lege =
+    Lege(godkjenninger = person.godkjenninger.godkjenning.map { ws2Godkjenning(it) })
+
+fun ws2Godkjenning(godkjenning: no.nhn.schemas.reg.hprv2.Godkjenning): Godkjenning =
+    Godkjenning(
+        helsepersonellkategori = ws2Kode(godkjenning.helsepersonellkategori),
+        autorisasjon = ws2Kode(godkjenning.autorisasjon)
+    )
+
+fun ws2Kode(kode: no.nhn.schemas.reg.common.no.Kode): Kode =
+    Kode(
+        aktiv = kode.isAktiv,
+        oid = kode.oid,
+        verdi = kode.verdi
+    )
+
+data class Lege(
+    val godkjenninger: List<Godkjenning> = emptyList()
+)
+
+data class Godkjenning(
+    val helsepersonellkategori: Kode? = null,
+    val autorisasjon: Kode? = null
+)
+
+data class Kode(
+    val aktiv: Boolean?,
+    val oid: Int? = null,
+    val verdi: String
+)

--- a/src/main/kotlin/no/nav/syfo/api/HelsepersonellClient.kt
+++ b/src/main/kotlin/no/nav/syfo/api/HelsepersonellClient.kt
@@ -51,9 +51,9 @@ class HelsepersonellClient(
             ws2Lege(wsHelsePerson)
                 .also {
                     log.info("fant lege i register med {} godkjenninger", it.godkjenninger.size)
-                    it.godkjenninger.forEach {godkjenning ->
-                        log.info("autorisasjon a/v/o: {}/{}/[}", godkjenning.autorisasjon?.aktiv, godkjenning.autorisasjon?.verdi, godkjenning.autorisasjon?.oid  )
-                        log.info("helsepersonell a/v/o: {}/{}/[}", godkjenning.helsepersonellkategori?.aktiv, godkjenning.helsepersonellkategori?.verdi, godkjenning.helsepersonellkategori?.oid  )
+                    it.godkjenninger.forEach { godkjenning ->
+                        log.info("autorisasjon a/v/o: {}/{}/[}", godkjenning.autorisasjon?.aktiv, godkjenning.autorisasjon?.verdi, godkjenning.autorisasjon?.oid)
+                        log.info("helsepersonell a/v/o: {}/{}/[}", godkjenning.helsepersonellkategori?.aktiv, godkjenning.helsepersonellkategori?.verdi, godkjenning.helsepersonellkategori?.oid)
                     }
                 }
         }

--- a/src/main/kotlin/no/nav/syfo/api/RuleApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/RuleApi.kt
@@ -39,17 +39,14 @@ import no.nav.tjeneste.virksomhet.person.v3.binding.PersonV3
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.NorskIdent
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.PersonIdent
 import no.nav.tjeneste.virksomhet.person.v3.meldinger.HentPersonRequest
-import no.nhn.schemas.reg.hprv2.IHPR2Service
 import no.nhn.schemas.reg.hprv2.IHPR2ServiceHentPersonMedPersonnummerGenericFaultFaultFaultMessage
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import java.util.GregorianCalendar
 import javax.xml.datatype.DatatypeFactory
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.Person as TPSPerson
-import no.nhn.schemas.reg.hprv2.Person as HPRPerson
 
 val log: Logger = LoggerFactory.getLogger("no.nav.syfo.smregler")
 
@@ -61,7 +58,12 @@ val objectMapper: ObjectMapper = ObjectMapper().apply {
 }
 
 @KtorExperimentalAPI
-fun Routing.registerRuleApi(personV3: PersonV3, helsepersonellv1: IHPR2Service, legeSuspensjonClient: LegeSuspensjonClient, syketilfelleClient: SyketilfelleClient) {
+fun Routing.registerRuleApi(
+    personV3: PersonV3,
+    helsepersonellClient: HelsepersonellClient,
+    legeSuspensjonClient: LegeSuspensjonClient,
+    syketilfelleClient: SyketilfelleClient
+) {
     post("/v1/rules/validate") {
         log.info("Got an request to validate rules")
 
@@ -73,10 +75,10 @@ fun Routing.registerRuleApi(personV3: PersonV3, helsepersonellv1: IHPR2Service, 
         val receivedSykmelding: ReceivedSykmelding = objectMapper.readValue(receivedSykmeldingText)
 
         val logValues = arrayOf(
-                keyValue("mottakId", receivedSykmelding.navLogId),
-                keyValue("organizationNumber", receivedSykmelding.legekontorOrgNr),
-                keyValue("msgId", receivedSykmelding.msgId),
-                keyValue("sykmeldingId", receivedSykmelding.sykmelding.id)
+            keyValue("mottakId", receivedSykmelding.navLogId),
+            keyValue("organizationNumber", receivedSykmelding.legekontorOrgNr),
+            keyValue("msgId", receivedSykmelding.msgId),
+            keyValue("sykmeldingId", receivedSykmelding.sykmelding.id)
         )
 
         val logKeys = logValues.joinToString(prefix = "(", postfix = ")", separator = ",") {
@@ -86,136 +88,155 @@ fun Routing.registerRuleApi(personV3: PersonV3, helsepersonellv1: IHPR2Service, 
         log.info("Received a SM2013, going to rules, $logKeys", *logValues)
 
         val validationAndPeriodRuleResults: List<Rule<Any>> = listOf<List<Rule<RuleData<RuleMetadata>>>>(
-                ValidationRuleChain.values().toList(),
-                PeriodLogicRuleChain.values().toList()
-        ).flatten().executeFlow(receivedSykmelding.sykmelding, RuleMetadata(
+            ValidationRuleChain.values().toList(),
+            PeriodLogicRuleChain.values().toList()
+        ).flatten().executeFlow(
+            receivedSykmelding.sykmelding, RuleMetadata(
                 receivedDate = receivedSykmelding.mottattDato,
                 signatureDate = receivedSykmelding.sykmelding.signaturDato,
                 patientPersonNumber = receivedSykmelding.personNrPasient,
                 rulesetVersion = receivedSykmelding.rulesetVersion,
                 legekontorOrgnr = receivedSykmelding.legekontorOrgNr,
                 tssid = receivedSykmelding.tssid
-        ))
+            )
+        )
 
+        val lege: Lege
         try {
-            val doctor = fetchDoctor(helsepersonellv1, receivedSykmelding.personNrLege).await()
+            lege = helsepersonellClient.hentLege(receivedSykmelding.personNrLege)
+        } catch (e: IHPR2ServiceHentPersonMedPersonnummerGenericFaultFaultFaultMessage) {
+            log.error(e.message)
+            val validationResult = ValidationResult(
+                status = Status.INVALID,
+                ruleHits = listOf(RuleInfo(
+                    ruleName = "BEHANDLER_NOT_IN_HPR",
+                    messageForSender = "Den som har skrevet sykmeldingen din har ikke autorisasjon til dette.",
+                    messageForUser = "Behandler er ikke register i HPR"))
+            )
+            RULE_HIT_STATUS_COUNTER.labels(validationResult.status.name).inc()
+            call.respond(validationResult)
+            return@post
+        }
 
-            val hprRuleResults = HPRRuleChain.values().executeFlow(receivedSykmelding.sykmelding, doctor)
+        val hprRuleResults = HPRRuleChain.values().executeFlow(receivedSykmelding.sykmelding, lege)
 
-            // TODO kun datagrunlag for å evt legge til ny regel på tannleger, slette denne if-setningen etterpå
-            if (doctor.godkjenninger.godkjenning.any {
-                        it?.helsepersonellkategori?.isAktiv != null &&
-                                it.autorisasjon?.isAktiv == true &&
-                                it.helsepersonellkategori.isAktiv != null &&
-                                it.helsepersonellkategori.verdi != null &&
-                                it.helsepersonellkategori.let { it.isAktiv && it.verdi in listOf("TL") &&
-                                        receivedSykmelding.sykmelding.medisinskVurdering.hovedDiagnose?.kode != null &&
-                                        receivedSykmelding.sykmelding.perioder.isNotEmpty() }
-                    }) {
-                log.info("Tannlege statestikk: " +
+        // TODO kun datagrunlag for å evt legge til ny regel på tannleger, slette denne if-setningen etterpå
+
+        if (lege.godkjenninger.any {
+                erGyldigTannlege(it) && sykmeldingMedDiagnoseOgPerioder(receivedSykmelding)
+            }) {
+            log.info(
+                "Tannlege statestikk: " +
                         "fom: ${receivedSykmelding.sykmelding.perioder.firstOrNull()?.fom} " +
                         "tom: ${receivedSykmelding.sykmelding.perioder.firstOrNull()?.tom} " +
-                        "houvedDiagnose: ${receivedSykmelding.sykmelding.medisinskVurdering.hovedDiagnose?.kode }")
-            }
-
-            val patient = fetchPerson(personV3, receivedSykmelding.personNrPasient)
-            val tpsRuleResults = PostTPSRuleChain.values().executeFlow(receivedSykmelding.sykmelding, patient.await())
-
-            val signaturDatoString = DateTimeFormatter.ofPattern("yyyy-MM-dd").format(receivedSykmelding.sykmelding.signaturDato)
-            val doctorSuspend = legeSuspensjonClient.checkTherapist(receivedSykmelding.personNrLege, receivedSykmelding.navLogId, signaturDatoString).suspendert
-            val doctorRuleResults = LegesuspensjonRuleChain.values().executeFlow(receivedSykmelding.sykmelding, doctorSuspend)
-
-            val erNyttSyketilfelle = syketilfelleClient.fetchErNytttilfelle(
-                    receivedSykmelding.sykmelding.perioder.intoSyketilfelle(
-                            receivedSykmelding.sykmelding.pasientAktoerId, receivedSykmelding.mottattDato, receivedSykmelding.msgId),
-                    receivedSykmelding.sykmelding.pasientAktoerId)
-
-            val ruleMetadataAndForstegangsSykemelding = RuleMetadataAndForstegangsSykemelding(
-                    ruleMetadata = RuleMetadata(
-                            receivedDate = receivedSykmelding.mottattDato,
-                            signatureDate = receivedSykmelding.sykmelding.signaturDato,
-                            patientPersonNumber = receivedSykmelding.personNrPasient,
-                            rulesetVersion = receivedSykmelding.rulesetVersion,
-                            legekontorOrgnr = receivedSykmelding.legekontorOrgNr,
-                            tssid = receivedSykmelding.tssid
-                    ), erNyttSyketilfelle = erNyttSyketilfelle
+                        "houvedDiagnose: ${receivedSykmelding.sykmelding.medisinskVurdering.hovedDiagnose?.kode}"
             )
-            val syketilfelleResults = SyketilfelleRuleChain.values().executeFlow(receivedSykmelding.sykmelding, ruleMetadataAndForstegangsSykemelding)
-            val results = listOf(
-                    validationAndPeriodRuleResults,
-                    tpsRuleResults,
-                    hprRuleResults,
-                    doctorRuleResults,
-                    syketilfelleResults
-            ).flatten()
-
-            log.info("Rules hit {}, $logKeys", results.map { it.name }, *logValues)
-
-            val validationResult = validationResult(results)
-            RULE_HIT_STATUS_COUNTER.labels(validationResult.status.name).inc()
-            call.respond(validationResult)
-        } catch (e: IHPR2ServiceHentPersonMedPersonnummerGenericFaultFaultFaultMessage) {
-            val validationResult = ValidationResult(
-                    status = Status.INVALID,
-                    ruleHits = listOf(RuleInfo(
-                            ruleName = "BEHANDLER_NOT_IN_HPR",
-                            messageForSender = "Den som har skrevet sykmeldingen din har ikke autorisasjon til dette.",
-                            messageForUser = "Behandler er ikke register i HPR"))
-            )
-            RULE_HIT_STATUS_COUNTER.labels(validationResult.status.name).inc()
-            call.respond(validationResult)
         }
+
+        val patient = fetchPerson(personV3, receivedSykmelding.personNrPasient)
+        val tpsRuleResults = PostTPSRuleChain.values().executeFlow(receivedSykmelding.sykmelding, patient.await())
+
+        val signaturDatoString =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd").format(receivedSykmelding.sykmelding.signaturDato)
+        val doctorSuspend = legeSuspensjonClient.checkTherapist(
+            receivedSykmelding.personNrLege,
+            receivedSykmelding.navLogId,
+            signaturDatoString
+        ).suspendert
+        val doctorRuleResults =
+            LegesuspensjonRuleChain.values().executeFlow(receivedSykmelding.sykmelding, doctorSuspend)
+
+        val erNyttSyketilfelle = syketilfelleClient.fetchErNytttilfelle(
+            receivedSykmelding.sykmelding.perioder.intoSyketilfelle(
+                receivedSykmelding.sykmelding.pasientAktoerId, receivedSykmelding.mottattDato, receivedSykmelding.msgId
+            ),
+            receivedSykmelding.sykmelding.pasientAktoerId
+        )
+
+        val ruleMetadataAndForstegangsSykemelding = RuleMetadataAndForstegangsSykemelding(
+            ruleMetadata = RuleMetadata(
+                receivedDate = receivedSykmelding.mottattDato,
+                signatureDate = receivedSykmelding.sykmelding.signaturDato,
+                patientPersonNumber = receivedSykmelding.personNrPasient,
+                rulesetVersion = receivedSykmelding.rulesetVersion,
+                legekontorOrgnr = receivedSykmelding.legekontorOrgNr,
+                tssid = receivedSykmelding.tssid
+            ), erNyttSyketilfelle = erNyttSyketilfelle
+        )
+        val syketilfelleResults = SyketilfelleRuleChain.values()
+            .executeFlow(receivedSykmelding.sykmelding, ruleMetadataAndForstegangsSykemelding)
+        val results = listOf(
+            validationAndPeriodRuleResults,
+            tpsRuleResults,
+            hprRuleResults,
+            doctorRuleResults,
+            syketilfelleResults
+        ).flatten()
+
+        log.info("Rules hit {}, $logKeys", results.map { it.name }, *logValues)
+
+        val validationResult = validationResult(results)
+        RULE_HIT_STATUS_COUNTER.labels(validationResult.status.name).inc()
+        call.respond(validationResult)
     }
 }
 
-fun CoroutineScope.fetchDoctor(hprService: IHPR2Service, doctorIdent: String): Deferred<HPRPerson> = async {
-    retry(
-            callName = "hpr_hent_person_med_personnummer",
-            retryIntervals = arrayOf(500L, 1000L, 3000L, 5000L, 10000L),
-            legalExceptions = *arrayOf(IOException::class, WstxException::class)
-    ) {
-        hprService.hentPersonMedPersonnummer(doctorIdent, datatypeFactory.newXMLGregorianCalendar(GregorianCalendar()))
-    }
+private fun erGyldigTannlege(
+    it: Godkjenning
+): Boolean {
+    return it.autorisasjon?.aktiv == true &&
+            it.helsepersonellkategori != null &&
+            it.helsepersonellkategori.aktiv == true &&
+            it.helsepersonellkategori.verdi == "TL"
 }
 
-fun List<Periode>.intoSyketilfelle(aktoerId: String, received: LocalDateTime, resourceId: String): List<Syketilfelle> = map {
-    Syketilfelle(
+private fun sykmeldingMedDiagnoseOgPerioder(receivedSykmelding: ReceivedSykmelding): Boolean {
+    return receivedSykmelding.sykmelding.medisinskVurdering.hovedDiagnose?.kode != null &&
+            receivedSykmelding.sykmelding.perioder.isNotEmpty()
+}
+
+fun List<Periode>.intoSyketilfelle(aktoerId: String, received: LocalDateTime, resourceId: String): List<Syketilfelle> =
+    map {
+        Syketilfelle(
             aktorId = aktoerId,
             orgnummer = null,
             inntruffet = received,
-            tags = listOf(SyketilfelleTag.SYKMELDING, SyketilfelleTag.PERIODE, when {
-                it.aktivitetIkkeMulig != null -> SyketilfelleTag.INGEN_AKTIVITET
-                it.reisetilskudd -> SyketilfelleTag.FULL_AKTIVITET
-                it.gradert != null -> SyketilfelleTag.GRADERT_AKTIVITET
-                it.behandlingsdager != null -> SyketilfelleTag.BEHANDLINGSDAGER
-                it.avventendeInnspillTilArbeidsgiver != null -> SyketilfelleTag.FULL_AKTIVITET
-                else -> throw RuntimeException("Could not find aktivitetstype, this should never happen")
-            }).joinToString(",") { tag -> tag.name },
+            tags = listOf(
+                SyketilfelleTag.SYKMELDING, SyketilfelleTag.PERIODE, when {
+                    it.aktivitetIkkeMulig != null -> SyketilfelleTag.INGEN_AKTIVITET
+                    it.reisetilskudd -> SyketilfelleTag.FULL_AKTIVITET
+                    it.gradert != null -> SyketilfelleTag.GRADERT_AKTIVITET
+                    it.behandlingsdager != null -> SyketilfelleTag.BEHANDLINGSDAGER
+                    it.avventendeInnspillTilArbeidsgiver != null -> SyketilfelleTag.FULL_AKTIVITET
+                    else -> throw RuntimeException("Could not find aktivitetstype, this should never happen")
+                }
+            ).joinToString(",") { tag -> tag.name },
             ressursId = resourceId,
             fom = it.fom.atStartOfDay(),
             tom = it.tom.atStartOfDay()
-    )
-}
+        )
+    }
 
 fun CoroutineScope.fetchPerson(personV3: PersonV3, ident: String): Deferred<TPSPerson> = async {
     retry(
-            callName = "tps_hent_person",
-            retryIntervals = arrayOf(500L, 1000L, 3000L, 5000L, 10000L, 60000L),
-            legalExceptions = *arrayOf(IOException::class, WstxException::class)
+        callName = "tps_hent_person",
+        retryIntervals = arrayOf(500L, 1000L, 3000L, 5000L, 10000L, 60000L),
+        legalExceptions = *arrayOf(IOException::class, WstxException::class)
     ) {
-        personV3.hentPerson(HentPersonRequest()
+        personV3.hentPerson(
+            HentPersonRequest()
                 .withAktoer(PersonIdent().withIdent(NorskIdent().withIdent(ident)))
         ).person
     }
 }
 
 fun validationResult(results: List<Rule<Any>>): ValidationResult =
-        ValidationResult(
-                status = results
-                        .map { status -> status.status }.let {
-                            it.firstOrNull { status -> status == Status.INVALID }
-                            ?: it.firstOrNull { status -> status == Status.MANUAL_PROCESSING }
-                            ?: Status.OK
-                        },
-                ruleHits = results.map { rule -> RuleInfo(rule.name, rule.messageForSender!!, rule.messageForUser!!) }
-        )
+    ValidationResult(
+        status = results
+            .map { status -> status.status }.let {
+                it.firstOrNull { status -> status == Status.INVALID }
+                    ?: it.firstOrNull { status -> status == Status.MANUAL_PROCESSING }
+                    ?: Status.OK
+            },
+        ruleHits = results.map { rule -> RuleInfo(rule.name, rule.messageForSender!!, rule.messageForUser!!) }
+    )

--- a/src/main/kotlin/no/nav/syfo/rules/HPRRuleChain.kt
+++ b/src/main/kotlin/no/nav/syfo/rules/HPRRuleChain.kt
@@ -1,16 +1,16 @@
 package no.nav.syfo.rules
 
+import no.nav.syfo.api.Lege
 import no.nav.syfo.model.Status
 import no.nav.syfo.sm.toICPC2
-import no.nhn.schemas.reg.hprv2.Person as HPRPerson
 
 enum class HPRRuleChain(
     override val ruleId: Int?,
     override val status: Status,
     override val messageForUser: String,
     override val messageForSender: String,
-    override val predicate: (RuleData<HPRPerson>) -> Boolean
-) : Rule<RuleData<HPRPerson>> {
+    override val predicate: (RuleData<Lege>) -> Boolean
+) : Rule<RuleData<Lege>> {
     @Description("Hvis manuellterapeut/kiropraktor eller fysioterapeut med autorisasjon har angitt annen diagnose enn kapitel L (muskel og skjelettsykdommer)skal meldingen til manuell behandling")
     BEHANDLER_KI_FT_MT_BENYTTER_ANNEN_DIAGNOSEKODE_ENN_L(
             1143,
@@ -19,13 +19,9 @@ enum class HPRRuleChain(
             "Behandler er manuellterapeut/kiropraktor eller fysioterapeut med autorisasjon har angitt annen diagnose enn kapitel L (muskel og skjelettsykdommer)",
             { (healthInformation, doctor) ->
                 healthInformation.medisinskVurdering.hovedDiagnose?.toICPC2()?.firstOrNull()?.code?.startsWith("L") == false &&
-                doctor.godkjenninger?.godkjenning != null &&
-                doctor.godkjenninger.godkjenning.any {
-                    it?.helsepersonellkategori?.isAktiv != null &&
-                            it.autorisasjon?.isAktiv == true &&
-                            it.helsepersonellkategori.isAktiv != null &&
-                            it.helsepersonellkategori.verdi != null &&
-                            it.helsepersonellkategori.let { it.isAktiv && it.verdi in listOf("KI", "MT", "FT") }
+                doctor.godkjenninger.any {
+                        it.autorisasjon?.aktiv == true &&
+                        it.helsepersonellkategori.let { helsepersonellkategori -> helsepersonellkategori?.aktiv == true && helsepersonellkategori.verdi in listOf("KI", "MT", "FT") }
                 }
     }),
 
@@ -35,8 +31,8 @@ enum class HPRRuleChain(
             Status.INVALID,
             "Den som skrev sykmeldingen manglet autorisasjon.",
             "Behandler er ikke gyldig i HPR på konsultasjonstidspunkt", { (_, doctor) ->
-        doctor.godkjenninger?.godkjenning != null && !doctor.godkjenninger.godkjenning.any {
-            it?.autorisasjon?.isAktiv != null && it.autorisasjon.isAktiv
+        !doctor.godkjenninger.any {
+            it.autorisasjon?.aktiv == true
         }
     }),
 
@@ -46,12 +42,9 @@ enum class HPRRuleChain(
             Status.INVALID,
             "Den som skrev sykmeldingen manglet autorisasjon.",
             "Behandler har ikke gyldig autorisasjon i HPR", { (_, doctor) ->
-        doctor.godkjenninger?.godkjenning != null && !doctor.godkjenninger.godkjenning.any {
-            it?.autorisasjon?.isAktiv != null &&
-            it.autorisasjon.isAktiv &&
-                    it.autorisasjon?.oid != null
+        !doctor.godkjenninger.any {
+            it.autorisasjon?.aktiv == true &&
                     it.autorisasjon.oid == 7704 &&
-                    it.autorisasjon?.verdi != null &&
                     it.autorisasjon.verdi in arrayOf("1", "17", "4", "3", "2", "14", "18")
         }
     }),
@@ -62,13 +55,10 @@ enum class HPRRuleChain(
             Status.INVALID,
             "Den som skrev sykmeldingen manglet autorisasjon.",
             "Behandler finnes i HPR men er ikke lege, kiropraktor, manuellterapeut, fysioterapeut eller tannlege", { (_, doctor) ->
-        doctor.godkjenninger?.godkjenning != null &&
-                !doctor.godkjenninger.godkjenning.any {
-                    it?.helsepersonellkategori?.isAktiv != null &&
-                    it.autorisasjon?.isAktiv == true &&
-                    it.helsepersonellkategori.isAktiv != null &&
-                    it.helsepersonellkategori.verdi != null &&
-                    it.helsepersonellkategori.let { it.isAktiv && it.verdi in listOf("LE", "KI", "MT", "TL", "FT") }
+                !doctor.godkjenninger.any {
+                    it.helsepersonellkategori?.aktiv == true &&
+                    it.autorisasjon?.aktiv == true &&
+                    it.helsepersonellkategori.let { helsepersonellkategori -> helsepersonellkategori.aktiv == true && helsepersonellkategori.verdi in listOf("LE", "KI", "MT", "TL", "FT") }
         }
     }),
 
@@ -80,13 +70,10 @@ enum class HPRRuleChain(
             "Behandler er manuellterapeut/kiropraktor eller fysioterapeut overstiger 12 uker regnet fra første sykefraværsdag", { (healthInformation, doctor) ->
 
         healthInformation.perioder.any { (it.fom..it.tom).daysBetween() > 84 } &&
-                doctor.godkjenninger?.godkjenning != null &&
-                doctor.godkjenninger.godkjenning.any {
-                    it?.helsepersonellkategori?.isAktiv != null &&
-                            it.autorisasjon?.isAktiv == true &&
-                            it.helsepersonellkategori.isAktiv != null &&
-                            it.helsepersonellkategori.verdi != null &&
-                            it.helsepersonellkategori.let { it.isAktiv && it.verdi in kotlin.collections.listOf("KI", "MT", "FT") }
+                doctor.godkjenninger.any {
+                    it.helsepersonellkategori?.aktiv != null &&
+                            it.autorisasjon?.aktiv == true &&
+                            it.helsepersonellkategori.let { helsepersonellkategori -> helsepersonellkategori.aktiv == true && helsepersonellkategori.verdi in listOf("KI", "MT", "FT") }
                 }
     }),
 }

--- a/src/test/kotlin/no/nav/syfo/SelftestSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/SelftestSpek.kt
@@ -15,6 +15,7 @@ import io.ktor.server.netty.Netty
 import io.ktor.server.testing.TestApplicationEngine
 import io.ktor.server.testing.handleRequest
 import io.ktor.util.KtorExperimentalAPI
+import no.nav.syfo.api.HelsepersonellClient
 import no.nav.syfo.api.LegeSuspensjonClient
 import no.nav.syfo.api.Oppfolgingstilfelle
 import no.nav.syfo.api.Periode
@@ -23,12 +24,10 @@ import no.nav.syfo.api.registerNaisApi
 import no.nav.syfo.client.OidcToken
 import no.nav.syfo.client.StsOidcClient
 import no.nav.tjeneste.virksomhet.person.v3.binding.PersonV3
-import no.nhn.schemas.reg.hprv2.IHPR2Service
 import org.amshove.kluent.shouldEqual
 import org.amshove.kluent.shouldNotEqual
 import org.apache.cxf.ext.logging.LoggingFeature
 import org.apache.cxf.jaxws.JaxWsProxyFactoryBean
-import org.apache.cxf.ws.addressing.WSAddressingFeature
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.net.ServerSocket
@@ -73,19 +72,13 @@ object SelftestSpek : Spek({
             serviceClass = PersonV3::class.java
         }.create() as PersonV3
 
-            val helsepersonellv1 = JaxWsProxyFactoryBean().apply {
-                address = "http://helsepersnolellv1/api"
-                features.add(LoggingFeature())
-                features.add(WSAddressingFeature())
-                serviceClass = IHPR2Service::class.java
-            }.create() as IHPR2Service
-
             val credentials = VaultCredentials("", "")
             val oidcClient = StsOidcClient("username", "password", "$mockHttpServerUrl/rest/v1/sts/token")
+            val helsepersonellClient = HelsepersonellClient("$mockHttpServerUrl/helsepersonell", "username", "password", "$mockHttpServerUrl/rest/v1/sts/token")
             val legeSuspensjonClient = LegeSuspensjonClient(mockHttpServerUrl, credentials, oidcClient)
             val syketilfelleClient = SyketilfelleClient(mockHttpServerUrl, oidcClient)
 
-            application.initRouting(applicationState, personV3, helsepersonellv1, legeSuspensjonClient, syketilfelleClient)
+            application.initRouting(applicationState, personV3, helsepersonellClient, legeSuspensjonClient, syketilfelleClient)
 
             it("Returns ok on is_alive") {
                 with(handleRequest(HttpMethod.Get, "/is_alive")) {

--- a/src/test/kotlin/no/nav/syfo/TestHelperSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/TestHelperSpek.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 object TestHelperSpek : Spek({
     fun date(year: Int, month: Int, day: Int) =
             LocalDate.of(year, month, day)
-    describe("Test helpers") {
+    describe("Lege helpers") {
         it("Monday to Sunday should return 4 week days") {
             workdaysBetween(date(2018, 10, 8), date(2018, 10, 14)) shouldEqual 4
         }

--- a/src/test/kotlin/no/nav/syfo/api/HelsepersonellClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/HelsepersonellClientSpek.kt
@@ -1,0 +1,40 @@
+package no.nav.syfo.api
+
+import no.nhn.schemas.reg.common.no.Kode
+import no.nhn.schemas.reg.hprv2.ArrayOfGodkjenning
+import no.nhn.schemas.reg.hprv2.Godkjenning
+import no.nhn.schemas.reg.hprv2.Person
+import org.amshove.kluent.shouldEqual
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object HelsepersonellClientSpek : Spek({
+    describe("HelsepersonellClient") {
+        it("Mapper ws-respons til domeneobjekt") {
+            val person = Person().apply {
+                godkjenninger = ArrayOfGodkjenning().apply {
+                    godkjenning.add(Godkjenning().apply {
+                        helsepersonellkategori = Kode().apply {
+                            autorisasjon = Kode().apply {
+                                isAktiv = false
+                                oid = 7704
+                                verdi = "1"
+                            }
+                            isAktiv = true
+                            verdi = "PL"
+                        }
+                    })
+                }
+            }
+            val lege = ws2Lege(person)
+
+            lege.godkjenninger.size shouldEqual 1
+            lege.godkjenninger[0].helsepersonellkategori?.aktiv shouldEqual true
+            lege.godkjenninger[0].helsepersonellkategori?.verdi shouldEqual "PL"
+
+            lege.godkjenninger[0].autorisasjon?.aktiv shouldEqual false
+            lege.godkjenninger[0].autorisasjon?.oid shouldEqual 7704
+            lege.godkjenninger[0].autorisasjon?.verdi shouldEqual "1"
+        }
+    }
+})


### PR DESCRIPTION
Jeg har dratt WS-klienten ut av bootstrap og inn i en egen klient. Denne eksponerer da et domeneobjekt nedover i applikasjonen, slik at vi ikke får sterke bindinger til ws-objektet. Da kunne jeg også forenkle noe logikk i reglene.